### PR TITLE
Scanning multiple sites in one pipeline.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 .bundle/
 .vagrant/
+env/
 
 *.swp
 results/
 Vagrantfile
 
 credentials.yml
+credentials.18F.yml

--- a/s3upload.py
+++ b/s3upload.py
@@ -1,0 +1,16 @@
+import tinys3
+import os
+import glob
+
+
+key = os.environ.get('S3_ACCESS_KEY', '')
+secret = os.environ.get('S3_SECRET_KEY', '')
+bucket = os.environ.get('S3_BUCKET', '')
+path = 'results/'
+
+conn = tinys3.Connection(key, secret, default_bucket=bucket)
+
+for infile in glob.glob(os.path.join(path, '*.json')):
+    result_file = open(infile, 'rb')
+    conn.upload(infile, result_file)
+

--- a/targets.json
+++ b/targets.json
@@ -1,0 +1,12 @@
+{
+  "targets": [
+    {
+      "name": "openopps",
+      "url": "https://openopps-staging.18f.gov/"
+    },
+    {
+      "name": "micropurchase",
+      "url" :"https://micropurchase.18f.gov"
+    }
+  ]
+}

--- a/test-owasp.sh
+++ b/test-owasp.sh
@@ -6,22 +6,23 @@ pip install tinys3
 COUNTER=0
 COUNT=$(cat scripts/targets.json | jq '.targets[] .url' | wc -l)
 
-zap-cli start --start-options '-config api.disablekey=true'
 
 while [ $COUNTER -lt $COUNT ]; do
   NAME=$(cat scripts/targets.json | jq ".targets[${COUNTER}] .name" -r)
   TARGET=$(cat scripts/targets.json | jq ".targets[${COUNTER}] .url" -r)
 
   echo Scanning $NAME: $TARGET
+  # Leaving ZAP up between runs allows alerts to accrue
+  zap-cli start --start-options '-config api.disablekey=true'
   zap-cli open-url $TARGET
   zap-cli spider $TARGET
   zap-cli active-scan -s all -r $TARGET
   zap-cli alerts -l Informational -f json > results/${NAME}.json
+  zap-cli shutdown
 
   let COUNTER+=1
 done
 
-zap-cli shutdown
 
 echo Uploading files...
 python scripts/s3upload.py

--- a/test-owasp.sh
+++ b/test-owasp.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
-zap-cli start --start-options '-config api.disablekey=true'
-zap-cli open-url $LIVE_TARGET
-zap-cli spider $LIVE_TARGET
-zap-cli active-scan -s all -r $LIVE_TARGET
-zap-cli alerts -l Informational -f json > results/zap.json
-zap-cli shutdown
+#zap-cli start --start-options '-config api.disablekey=true'
+#zap-cli open-url $LIVE_TARGET
+#zap-cli spider $LIVE_TARGET
+#zap-cli active-scan -s all -r $LIVE_TARGET
+#zap-cli alerts -l Informational -f json > results/zap.json
+#zap-cli shutdown
 
+touch results/zap.json
 cp results/zap.json results.zap2.json
 
 exit 0

--- a/test-owasp.sh
+++ b/test-owasp.sh
@@ -7,4 +7,6 @@ zap-cli active-scan -s all -r $LIVE_TARGET
 zap-cli alerts -l Informational -f json > results/zap.json
 zap-cli shutdown
 
+cp results/zap.json results.zap2.json
+
 exit 0

--- a/test-owasp.sh
+++ b/test-owasp.sh
@@ -1,10 +1,28 @@
 #!/bin/bash
-#pip install --upgrade git+https://github.com/Grunny/zap-cli.git
+
+apt-get install jq
+pip install tinys3
+
+COUNTER=0
+COUNT=$(cat scripts/targets.json | jq '.targets[] .url' | wc -l)
 
 zap-cli start --start-options '-config api.disablekey=true'
-zap-cli open-url $LIVE_TARGET
-zap-cli active-scan -s all -r $LIVE_TARGET
-zap-cli alerts -l Low -f json > results/zap.json
+
+while [ $COUNTER -lt $COUNT ]; do
+  NAME=$(cat scripts/targets.json | jq ".targets[${COUNTER}] .name" -r)
+  TARGET=$(cat scripts/targets.json | jq ".targets[${COUNTER}] .url" -r)
+
+  echo Scanning $NAME: $TARGET
+  zap-cli open-url $TARGET
+  zap-cli spider $TARGET
+  zap-cli active-scan -s all -r $TARGET
+  zap-cli alerts -l Informational -f json > results/${NAME}.json
+
+  let COUNTER+=1
+done
+
 zap-cli shutdown
 
-exit 0
+echo Uploading files...
+python scripts/s3upload.py
+

--- a/test-owasp.sh
+++ b/test-owasp.sh
@@ -6,23 +6,21 @@ pip install tinys3
 COUNTER=0
 COUNT=$(cat scripts/targets.json | jq '.targets[] .url' | wc -l)
 
+zap-cli start --start-options '-config api.disablekey=true'
 
 while [ $COUNTER -lt $COUNT ]; do
   NAME=$(cat scripts/targets.json | jq ".targets[${COUNTER}] .name" -r)
   TARGET=$(cat scripts/targets.json | jq ".targets[${COUNTER}] .url" -r)
 
   echo Scanning $NAME: $TARGET
-  # Leaving ZAP up between runs allows alerts to accrue
-  zap-cli start --start-options '-config api.disablekey=true'
-  zap-cli open-url $TARGET
-  zap-cli spider $TARGET
-  zap-cli active-scan -s all -r $TARGET
+  zap-cli quick-scan --spider --scanners all $TARGET
   zap-cli alerts -l Informational -f json > results/${NAME}.json
-  zap-cli shutdown
+  zap-cli session new
 
   let COUNTER+=1
 done
 
+zap-cli shutdown
 
 echo Uploading files...
 python scripts/s3upload.py

--- a/zap-ondemand.yml
+++ b/zap-ondemand.yml
@@ -1,0 +1,19 @@
+resources:
+- name: scripts 
+  type: git
+  source:
+    uri: https://github.com/18F/concourse-compliance-testing.git
+    branch: {{script-branch}} 
+
+jobs:
+- name: zap-scan 
+  plan:
+  - get: scripts 
+  - task: scan-owasp
+    file: scripts/task-owasp.yml
+    config:
+      params:
+        S3_ACCESS_KEY: {{aws-access-key}}
+        S3_SECRET_KEY: {{aws-secret-key}}
+        S3_BUCKET: {{aws-bucket}}
+

--- a/zap-ondemand.yml
+++ b/zap-ondemand.yml
@@ -2,7 +2,8 @@ resources:
 - name: scripts 
   type: git
   source:
-    uri: https://github.com/DavidEBest/concourse-compliance-testing.git 
+    uri: https://github.com/18F/concourse-compliance-testing.git
+    branch: multi-file
 - name: zap-collector-json
   type: s3
   source:

--- a/zap-ondemand.yml
+++ b/zap-ondemand.yml
@@ -22,5 +22,5 @@ jobs:
         LIVE_TARGET: {{live-target}}
   - put: zap-collector-json
     params:
-      from: results/zap.json
+      from: results
 

--- a/zap-pipeline.yml
+++ b/zap-pipeline.yml
@@ -1,0 +1,26 @@
+resources:
+- name: scripts 
+  type: git
+  source:
+    uri: https://github.com/18F/concourse-compliance-testing.git 
+    branch: {{script-branch}}
+- name: after-midnight
+  type: time
+  source:
+    start: 12:00 AM -0500
+    stop: 12:30 AM -0500
+
+jobs:
+- name: zap-scan 
+  plan:
+  - get: after-midnight
+    trigger: true
+  - get: scripts 
+  - task: scan-owasp
+    file: scripts/task-owasp.yml
+    config:
+      params:
+        S3_ACCESS_KEY: {{aws-access-key}}
+        S3_SECRET_KEY: {{aws-secret-key}}
+        S3_BUCKET: {{aws-bucket}}
+


### PR DESCRIPTION
The Concourse S3 resource does not support uploading multiple files. This commit switches the S3 uploading to be handled in process, instead of by Concourse itself.

The list of targets comes from a json file in this repository (targets.json), and the result files are written to results/{name of app}.json.
