### PR TITLE
Adding support for the ajax-spider to the scan.

### DIFF
--- a/scripts/test-zap.sh
+++ b/scripts/test-zap.sh
@@ -3,6 +3,8 @@
 apt-get install jq
 pip install tinys3
 
+pip install --upgrade zapcli 
+
 COUNTER=0
 COUNT=$(cat scripts/targets.json | jq '.targets[] .url' | wc -l)
 
@@ -13,7 +15,7 @@ while [ $COUNTER -lt $COUNT ]; do
   TARGET=$(cat scripts/targets.json | jq ".targets[${COUNTER}] .url" -r)
 
   echo Scanning $NAME: $TARGET
-  zap-cli quick-scan --spider --scanners all $TARGET
+  zap-cli -v quick-scan --spider --ajax-spider --scanners all $TARGET
   zap-cli alerts -l Informational -f json > results/${NAME}.json
   zap-cli session new
 


### PR DESCRIPTION
zap-cli recently added support for the ajax-spider. This change updates the zap-cli client and adds the ajax spider to the list of components to run. Additionally, the `-v` flag was added to the `quick-scan` command to improve debugability.
