### PR TITLE
Correcting the syntax of the slack channel name in the config.

### DIFF
--- a/config/prod.example.yml
+++ b/config/prod.example.yml
@@ -8,7 +8,7 @@ script-branch: master
 # webhook for Slack (described here: https://api.slack.com/incoming-webhooks)
 slack-hook:
 # which channel should get notified?
-slack-channel: compliance-toolkit
+slack-channel: '#compliance-toolkit'
 # url to image to use for the Slack user
 slack-icon: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
 # name for the slack user


### PR DESCRIPTION
The channel name has to be specified in quotes with a hashtag. Otherwise it returns

```
Invalid channel specified
json: cannot unmarshal number into Go value of type string
```
