### PR TITLE
Switching to use the latest slack notification resource.

### DIFF
--- a/pipelines/zap.yml
+++ b/pipelines/zap.yml
@@ -3,10 +3,6 @@
 #   fly set-pipeline -t lite -n -c pipelines/zap.yml -p zap --load-vars-from config/local.yml -v script-branch=`git rev-parse --abbrev-ref HEAD`
 #
 resource_types:
-- name: slack-notification
-  type: docker-image
-  source:
-    repository: nopik/slack-notification-resource
 - name: s3-upload
   type: docker-image
   source:
@@ -41,6 +37,7 @@ jobs:
   - get: scripts
   - task: scan-zap
     file: scripts/tasks/run-zap/task.yml
+  - put: s3-bucket
   - put: slack
     params:
       channel: {{slack-channel}}
@@ -49,10 +46,17 @@ jobs:
         :white_check_mark: Completed scan of configured properties.
         <https://compliance-viewer.18f.gov/results|View results>
       username: {{slack-user}}
-  - put: s3-bucket
 - name: zap-ondemand
   plan:
   - get: scripts
   - task: scan-zap
     file: scripts/tasks/run-zap/task.yml
   - put: s3-bucket
+  - put: slack
+    params:
+      channel: {{slack-channel}}
+      icon_url: {{slack-icon}}
+      text: |
+        :white_check_mark: Completed scan of configured properties.
+        <https://compliance-viewer.18f.gov/results|View results>
+      username: {{slack-user}}

--- a/pipelines/zap.yml
+++ b/pipelines/zap.yml
@@ -2,6 +2,11 @@
 #
 #   fly set-pipeline -t lite -n -c pipelines/zap.yml -p zap --load-vars-from config/local.yml -v script-branch=`git rev-parse --abbrev-ref HEAD`
 #
+
+# Previously we defined the slack notification as a resource, but the one on
+# docker hub (https://hub.docker.com/r/nopik/slack-notification-resource/) is
+# outdated. Instead, we ae using cloud.gov's built-in version
+# (https://github.com/18F/slack-notification-resource-boshrelease).
 resource_types:
 - name: s3-upload
   type: docker-image


### PR DESCRIPTION
Defining the `resource_type` for the Slack notification caused the pipeline to pull the outdated version from docker hub (https://hub.docker.com/r/nopik/slack-notification-resource/) instead of the built-in version we're using (https://github.com/18F/slack-notification-resource-boshrelease). There is an open issue for this here: https://github.com/cloudfoundry-community/slack-notification-resource/issues/10

Additionally, I moved the slack notification to the end of list of tasks. It was erroring after it notified the user of success, but before the files were actually uploaded, which is probably the worst way for this to error out. :)

Finally, I added the notification to the ondemand job.
