### PR TITLE
switch to use newly-published S3 Resource from Docker Hub

### DIFF
--- a/pipelines/zap.yml
+++ b/pipelines/zap.yml
@@ -7,6 +7,7 @@ resource_types:
   type: docker-image
   source:
     repository: cfcommunity/slack-notification-resource
+    tag: v1.0.0
 - name: s3-upload
   type: docker-image
   source:

--- a/pipelines/zap.yml
+++ b/pipelines/zap.yml
@@ -2,12 +2,11 @@
 #
 #   fly set-pipeline -t lite -n -c pipelines/zap.yml -p zap --load-vars-from config/local.yml -v script-branch=`git rev-parse --abbrev-ref HEAD`
 #
-
-# Previously we defined the slack notification as a resource, but the one on
-# docker hub (https://hub.docker.com/r/nopik/slack-notification-resource/) is
-# outdated. Instead, we ae using cloud.gov's built-in version
-# (https://github.com/18F/slack-notification-resource-boshrelease).
 resource_types:
+- name: slack-notification
+  type: docker-image
+  source:
+    repository: cfcommunity/slack-notification-resource
 - name: s3-upload
   type: docker-image
   source:


### PR DESCRIPTION
Reverts part of https://github.com/18F/concourse-compliance-testing/pull/17, now that the Slack resource with the new config we need is released. Verified locally, which posted https://18f.slack.com/archives/compliance-toolkit/p1458683332000487.
