### PR TITLE
disable manual triggering of scheduled pipeline

### DIFF
--- a/pipelines/zap.yml
+++ b/pipelines/zap.yml
@@ -50,6 +50,8 @@ resources:
     etag: true
 jobs:
 - name: zap-scheduled
+  # use of the `time` Resource blocks manual triggering, so might as well remove the option
+  disable_manual_trigger: true
   plan:
   - get: after-midnight
     trigger: true
@@ -74,7 +76,7 @@ jobs:
       put: slack
       params:
         text: |
-          :x: FAILED to scan properties. 
+          :x: FAILED to scan properties.
           <https://ci.cloud.gov/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
         channel: {{slack-channel}}
         username: {{slack-user}}
@@ -102,7 +104,7 @@ jobs:
       put: slack
       params:
         text: |
-          :x: FAILED to scan properties. 
+          :x: FAILED to scan properties.
           <https://ci.cloud.gov/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
         channel: {{slack-channel}}
         username: {{slack-user}}


### PR DESCRIPTION
See inline comment for background. I saw this option in the [0.76.0 release notes](http://concourse.ci/release-notes.html#section_v0.76.0), but [Concourse's Vagrant build is failing](http://ci.concourse.ci/pipelines/main/jobs/virtualbox-testflight/builds/50), so haven't actually been able to test it :smirk: Happy to keep this open until that happens.
