### PR TITLE
Removing unnecessary overrides & uscis

### DIFF
--- a/tasks/filter-team-data/targets.json
+++ b/tasks/filter-team-data/targets.json
@@ -48,12 +48,7 @@
     ]
   },
   {
-    "name": "c2",
-    "links": [
-      {
-        "url": "https://cap.18f.gov/"
-      }
-    ]
+    "name": "c2"
   },
   {
     "name": "atf-eregs",
@@ -64,19 +59,6 @@
     ]
   },
   {
-    "name": "federalist",
-    "links": [
-      {
-        "url": "https://federalist.18f.gov/"
-      }
-    ]
-  },
-  {
-    "name": "uscis",
-    "links": [
-      {
-        "url": "https://save-ferris-dev.18f.gov/"
-      }
-    ]
+    "name": "federalist"
   }
 ]


### PR DESCRIPTION
Save Ferris backed out of being involved in the test, so removing them from the list.

Also, as per https://github.com/18F/concourse-compliance-testing/pull/30#issuecomment-203014062, I'm removing the unnecessary overrides from the list.
