### PR TITLE
Adding support for scanning multiple urls per target.

### DIFF
--- a/tasks/filter-team-data/targets.json
+++ b/tasks/filter-team-data/targets.json
@@ -4,6 +4,9 @@
     "links": [
       {
         "url": "https://openopps-staging.18f.gov/"
+      },
+      {
+        "url": "https://openopps.digitalgov.gov/"
       }
     ]
   },
@@ -12,49 +15,6 @@
     "links": [
       {
         "url": "https://micropurchase.18f.gov"
-      }
-    ]
-  },
-  {
-    "name": "api-data-gov",
-    "links": [
-      {
-        "url": "https://api.data.gov/"
-      }
-    ]
-  },
-  {
-    "name": "dap",
-    "links": [
-      {
-        "url": "https://analytics.usa.gov/"
-      }
-    ]
-  },
-  {
-    "name": "pulse",
-    "links": [
-      {
-        "url": "https://pulse.cio.gov/"
-      }
-    ]
-  },
-  {
-    "name": "confidential-survey",
-    "links": [
-      {
-        "url": "https://survey.apps.cloud.gov/"
-      }
-    ]
-  },
-  {
-    "name": "c2"
-  },
-  {
-    "name": "atf-eregs",
-    "links": [
-      {
-        "url": "https://atf-eregs-demo.apps.cloud.gov/"
       }
     ]
   },

--- a/tasks/filter-team-data/targets.json
+++ b/tasks/filter-team-data/targets.json
@@ -4,9 +4,6 @@
     "links": [
       {
         "url": "https://openopps-staging.18f.gov/"
-      },
-      {
-        "url": "https://openopps.digitalgov.gov/"
       }
     ]
   },
@@ -15,6 +12,52 @@
     "links": [
       {
         "url": "https://micropurchase.18f.gov"
+      }
+    ]
+  },
+  {
+    "name": "api-data-gov",
+    "links": [
+      {
+        "url": "https://api.data.gov/"
+      }
+    ]
+  },
+  {
+    "name": "dap",
+    "links": [
+      {
+        "url": "https://analytics.usa.gov/"
+      }
+    ]
+  },
+  {
+    "name": "pulse",
+    "links": [
+      {
+        "url": "https://pulse.cio.gov/"
+      }
+    ]
+  },
+  {
+    "name": "confidential-survey",
+    "links": [
+      {
+        "url": "https://survey.apps.cloud.gov/"
+      }
+    ]
+  },
+  {
+    "name": "c2"
+  },
+  {
+    "name": "atf-eregs",
+    "links": [
+      {
+        "url": "https://atf-eregs-demo.apps.cloud.gov/"
+      },
+      {
+        "url": "https://eregsnc-demo.apps.cloud.gov/"
       }
     ]
   },

--- a/tasks/run-zap/task.sh
+++ b/tasks/run-zap/task.sh
@@ -3,6 +3,8 @@
 set -e
 set -x
 
+mkdir tmp
+
 apt-get install jq
 pip install --upgrade zapcli
 
@@ -14,14 +16,19 @@ zap-cli start --start-options '-config api.disablekey=true'
 while [ "$COUNTER" -lt "$COUNT" ]; do
   NAME=$(jq -r ".[${COUNTER}] .name" < filtered-projects/projects.json)
   # TODO scan all links
-  TARGET=$(jq -r ".[${COUNTER}] .links | .[0] | .url" < filtered-projects/projects.json)
+  LINK_COUNTER=0
+  LINK_COUNT=$(jq ".[${COUNTER}] .links | length" < filtered-projects/projects.json)
+  while [ "$LINK_COUNTER" -lt "$LINK_COUNT" ]; do
+    TARGET=$(jq -r ".[${COUNTER}] .links | .[${LINK_COUNTER}] | .url" < filtered-projects/projects.json)
 
-  echo "Scanning $NAME: $TARGET"
-  zap-cli -v quick-scan --spider --ajax-spider --scanners all "$TARGET"
-  # `zap-cli alerts` returns an error code if there are any warnings - ignore them so the script doesn't fail
-  zap-cli alerts -l Informational -f json > "results/${NAME}.json" || true
-  zap-cli session new
-
+    echo "Scanning $NAME: $TARGET"
+    zap-cli -v quick-scan --spider --ajax-spider --scanners all "$TARGET"
+    # `zap-cli alerts` returns an error code if there are any warnings - ignore them so the script doesn't fail
+    zap-cli alerts -l Informational -f json > "tmp/${NAME}.${LINK_COUNTER}.json" || true
+    zap-cli session new
+    let LINK_COUNTER+=1
+  done
+  jq --slurp '[.[] | .[]]' tmp/${NAME}.*.json > results/${NAME}.json
   let COUNTER+=1
 done
 

--- a/tasks/run-zap/task.sh
+++ b/tasks/run-zap/task.sh
@@ -22,7 +22,7 @@ while [ "$COUNTER" -lt "$COUNT" ]; do
     TARGET=$(jq -r ".[${COUNTER}] .links | .[${LINK_COUNTER}] | .url" < filtered-projects/projects.json)
 
     echo "Scanning $NAME: $TARGET"
-    zap-cli -v quick-scan --spider --ajax-spider --scanners all "$TARGET"
+    zap-cli -v quick-scan --spider --ajax-spider --scanners all "$TARGET" || true
     # `zap-cli alerts` returns an error code if there are any warnings - ignore them so the script doesn't fail
     zap-cli alerts -l Informational -f json > "tmp/${NAME}.${LINK_COUNTER}.json" || true
     zap-cli session new

--- a/tasks/run-zap/task.sh
+++ b/tasks/run-zap/task.sh
@@ -28,7 +28,7 @@ while [ "$COUNTER" -lt "$COUNT" ]; do
     zap-cli session new
     let LINK_COUNTER+=1
   done
-  jq --slurp '[.[] | .[]]' tmp/${NAME}.*.json > results/${NAME}.json
+  jq --slurp '[.[] | .[]]' "tmp/${NAME}.*.json" > "results/${NAME}.json"
   let COUNTER+=1
 done
 


### PR DESCRIPTION
This adds support for scanning multiple urls per target. The data is combined into a single report file. You can see an example of the output for this here: 

https://compliance-viewer.18f.gov/results/openopps/_e0pCNT4oieDVlnNlZFidzovfPnJC1Sk

It functions by looping over the links array and running zap against each url that is discovered. The output for these scans are put in a temporary file. Once all the scans are completed, `jq` is used to merge the arrays and move them to the `results` directory.
