### PR TITLE
Downcasing target and project names before using them.

### DIFF
--- a/tasks/filter-team-data/team_data_filterer.rb
+++ b/tasks/filter-team-data/team_data_filterer.rb
@@ -21,6 +21,8 @@ module TeamDataFilterer
     def transform_project(project, target)
       result = project.merge(target)
 
+      result['name'] = result['name'].downcase
+
       # not always present in about.yml
       links = result['links'] || []
       result['links'] = transform_links(links)
@@ -56,8 +58,7 @@ module TeamDataFilterer
     end
 
     def build_target(target, p_by_name)
-      target['name'].downcase!
-      name = target['name']
+      name = target['name'].downcase
       project = p_by_name[name]
 
       unless project

--- a/tasks/filter-team-data/team_data_filterer.rb
+++ b/tasks/filter-team-data/team_data_filterer.rb
@@ -49,13 +49,14 @@ module TeamDataFilterer
     def projects_by_name(projects)
       results = {}
       projects.each do |project|
-        name = project['name']
+        name = project['name'].downcase
         results[name] = project
       end
       results
     end
 
     def build_target(target, p_by_name)
+      target['name'].downcase!
       name = target['name']
       project = p_by_name[name]
 

--- a/tasks/filter-team-data/test/test_team_data_filterer.rb
+++ b/tasks/filter-team-data/test/test_team_data_filterer.rb
@@ -1,6 +1,12 @@
 require 'minitest/autorun'
 require_relative '../team_data_filterer'
 
+def simple_project(name = "foo", options = {})
+  {
+    "name" => name
+  }.merge options
+end
+
 describe TeamDataFilterer do
   describe '.transform_links' do
     it "converts String `links` to the Hash format" do
@@ -45,8 +51,8 @@ describe TeamDataFilterer do
     end
 
     it "sets `links` if not present" do
-      project = { "name" => "foo" }
-      target = { "name" => "foo" }
+      project = simple_project("foo")
+      target = simple_project("foo")
 
       result = TeamDataFilterer.transform_project(project, target)
       expect(result).must_equal(
@@ -69,9 +75,7 @@ describe TeamDataFilterer do
           "something" => 7
         }
       ]
-      targets = [
-        { "name" => "bar" }
-      ]
+      targets = [simple_project("bar")]
 
       results = TeamDataFilterer.filtered_projects(projects, targets)
       expect(results).must_equal [
@@ -84,9 +88,7 @@ describe TeamDataFilterer do
     end
 
     it "handles a target not present in the projects" do
-      targets = [
-        { "name" => "foo" }
-      ]
+      targets = [simple_project("foo")]
 
       results = TeamDataFilterer.filtered_projects([], targets)
       expect(results).must_equal [
@@ -98,22 +100,9 @@ describe TeamDataFilterer do
     end
 
     it "downcases target names when filtering projects" do
-      projects = [
-        {
-          "name" => "foo",
-          "links" => []
-        },
-        {
-          "name" => "bar",
-          "links" => [],
-          "something" => 7
-        }
-      ]
-      targets = [
-        { "name" => "FOO" }
-      ]
-
-      results = TeamDataFilterer.filtered_projects(projects, targets)
+      results = TeamDataFilterer.filtered_projects(
+        [simple_project("foo")], [simple_project("FOO")]
+      )
       expect(results).must_equal [
         {
           "name" => "foo",
@@ -123,22 +112,9 @@ describe TeamDataFilterer do
     end
 
     it "downcases project names when filtering projects" do
-      projects = [
-        {
-          "name" => "FOO",
-          "links" => []
-        },
-        {
-          "name" => "bar",
-          "links" => [],
-          "something" => 7
-        }
-      ]
-      targets = [
-        { "name" => "foo" }
-      ]
-
-      results = TeamDataFilterer.filtered_projects(projects, targets)
+      results = TeamDataFilterer.filtered_projects(
+        [simple_project("FOO")], [simple_project("foo")]
+      )
       expect(results).must_equal [
         {
           "name" => "foo",

--- a/tasks/filter-team-data/test/test_team_data_filterer.rb
+++ b/tasks/filter-team-data/test/test_team_data_filterer.rb
@@ -96,5 +96,55 @@ describe TeamDataFilterer do
         }
       ]
     end
+
+    it "downcases target names when filtering projects" do
+      projects = [
+        {
+          "name" => "foo",
+          "links" => []
+        },
+        {
+          "name" => "bar",
+          "links" => [],
+          "something" => 7
+        }
+      ]
+      targets = [
+        { "name" => "FOO" }
+      ]
+
+      results = TeamDataFilterer.filtered_projects(projects, targets)
+      expect(results).must_equal [
+        {
+          "name" => "foo",
+          "links" => []
+        }
+      ]
+    end
+
+    it "downcases project names when filtering projects" do
+      projects = [
+        {
+          "name" => "FOO",
+          "links" => []
+        },
+        {
+          "name" => "bar",
+          "links" => [],
+          "something" => 7
+        }
+      ]
+      targets = [
+        { "name" => "foo" }
+      ]
+
+      results = TeamDataFilterer.filtered_projects(projects, targets)
+      expect(results).must_equal [
+        {
+          "name" => "foo",
+          "links" => []
+        }
+      ]
+    end
   end
 end


### PR DESCRIPTION
We ran into an issue with `C2`, which was specified in the targets.json file as `c2`, in the team-api as `C2`, and as a team-api url as `c2`. Since the team-api urls are downcased, it makes the most sense to standardize on that format here.

Just downcasing them should prevent tasks further along in the pipeline (or compliance-viewer) from needing to think about this.

Addresses #33
