### PR TITLE
post ZAP notifications for each project in the corresponding channel

### DIFF
--- a/config/targets.json
+++ b/config/targets.json
@@ -5,8 +5,7 @@
       {
         "url": "https://openopps-staging.18f.gov/"
       }
-    ],
-    "slack_channel": "openopps-platform"
+    ]
   },
   {
     "name": "micropurchase",
@@ -14,8 +13,7 @@
       {
         "url": "https://micropurchase.18f.gov"
       }
-    ],
-    "slack_channel": "micropurchase"
+    ]
   },
   {
     "name": "api-data-gov",
@@ -23,8 +21,7 @@
       {
         "url": "https://api.data.gov/"
       }
-    ],
-    "slack_channel": "wg-api"
+    ]
   },
   {
     "name": "dap",
@@ -32,8 +29,7 @@
       {
         "url": "https://analytics.usa.gov/"
       }
-    ],
-    "slack_channel": "dap"
+    ]
   },
   {
     "name": "pulse",
@@ -41,8 +37,7 @@
       {
         "url": "https://pulse.cio.gov/"
       }
-    ],
-    "slack_channel": "pulse"
+    ]
   },
   {
     "name": "confidential-survey",
@@ -50,12 +45,10 @@
       {
         "url": "https://survey.apps.cloud.gov/"
       }
-    ],
-    "slack_channel": "wg-diversity"
+    ]
   },
   {
-    "name": "c2",
-    "slack_channel": "cap"
+    "name": "c2"
   },
   {
     "name": "atf-eregs",
@@ -66,8 +59,7 @@
       {
         "url": "https://eregsnc-demo.apps.cloud.gov/"
       }
-    ],
-    "slack_channel": "atf-eregs"
+    ]
   },
   {
     "name": "federalist",

--- a/config/targets.json
+++ b/config/targets.json
@@ -5,7 +5,8 @@
       {
         "url": "https://openopps-staging.18f.gov/"
       }
-    ]
+    ],
+    "slack_channel": "openopps-platform"
   },
   {
     "name": "micropurchase",
@@ -13,7 +14,8 @@
       {
         "url": "https://micropurchase.18f.gov"
       }
-    ]
+    ],
+    "slack_channel": "micropurchase"
   },
   {
     "name": "api-data-gov",
@@ -21,7 +23,8 @@
       {
         "url": "https://api.data.gov/"
       }
-    ]
+    ],
+    "slack_channel": "wg-api"
   },
   {
     "name": "dap",
@@ -29,7 +32,8 @@
       {
         "url": "https://analytics.usa.gov/"
       }
-    ]
+    ],
+    "slack_channel": "dap"
   },
   {
     "name": "pulse",
@@ -37,7 +41,8 @@
       {
         "url": "https://pulse.cio.gov/"
       }
-    ]
+    ],
+    "slack_channel": "pulse"
   },
   {
     "name": "confidential-survey",
@@ -45,10 +50,12 @@
       {
         "url": "https://survey.apps.cloud.gov/"
       }
-    ]
+    ],
+    "slack_channel": "wg-diversity"
   },
   {
-    "name": "c2"
+    "name": "c2",
+    "slack_channel": "cap"
   },
   {
     "name": "atf-eregs",
@@ -59,9 +66,11 @@
       {
         "url": "https://eregsnc-demo.apps.cloud.gov/"
       }
-    ]
+    ],
+    "slack_channel": "atf-eregs"
   },
   {
-    "name": "federalist"
+    "name": "federalist",
+    "slack_channel": "federalist"
   }
 ]

--- a/pipelines/zap/pipeline.yml
+++ b/pipelines/zap/pipeline.yml
@@ -87,7 +87,7 @@ jobs:
     on_success:
       put: slack
       params:
-        channel: {{slack-channel}}
+        channel: "<%= project['slack_channel'] ? "##{project['slack_channel']}" : "{{slack-channel}}" %>"
         icon_url: {{slack-icon}}
         text_file: zap-summary/summary.txt
         username: {{slack-user}}


### PR DESCRIPTION
Builds on #34.

https://trello.com/c/AGdbPw7P/74-as-a-user-i-want-to-be-notified-when-a-zap-scan-is-complete

This will post the results of ZAP scans in the channel corresponding to each project, and any pipeline failures into our centralized channel. Do we want to see the successes in there too in the near term, just to build up confidence that it's working?

Since https://github.com/18F/about_yml/issues/85 is still open, just added the Slack channel names as custom fields in the `targets.json`.
