### PR TITLE
fix Rake test running

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,3 @@ before_install:
 language: ruby
 rvm:
  - 2.2
-script:
-  - rake

--- a/Rakefile
+++ b/Rakefile
@@ -5,9 +5,11 @@ Rake::TestTask.new do |t|
   t.pattern = '**/test_*.rb'
 end
 
-# Javascript tests
-Rake::TestTask.new do
-  puts `cd tasks/uptime-check && mocha`
+desc "Run JavaScript tests"
+task :js_tests do
+  Dir.chdir('tasks/uptime-check') do
+    sh 'mocha'
+  end
 end
 
-task default: :test
+task default: [:test, :js_tests]


### PR DESCRIPTION
Fixed a couple issues:
- Rake wasn't exiting with an error code if the `mocha` tests failed
- `rake` was running all the minitest tests twice
