### PR TITLE
fix quoting of templatized values in ZAP pipeline

### DIFF
--- a/pipelines/zap/pipeline.yml
+++ b/pipelines/zap/pipeline.yml
@@ -87,7 +87,7 @@ jobs:
     on_success:
       put: slack
       params:
-        channel: "<%= project['slack_channel'] ? "##{project['slack_channel']}" : "{{slack-channel}}" %>"
+        channel: <%= project['slack_channel'] ? "'##{project['slack_channel']}'" : "{{slack-channel}}" %>
         icon_url: {{slack-icon}}
         text_file: zap-summary/summary.txt
         username: {{slack-user}}

--- a/pipelines/zap/test/test_pipeline_builder.rb
+++ b/pipelines/zap/test/test_pipeline_builder.rb
@@ -42,13 +42,12 @@ describe PipelineBuilder do
     end
 
     it "uses the templatized Slack channel when none is specified" do
-      data = build_for([
+      builder = PipelineBuilder.new([
         { 'name' => 'foo' }
       ])
-
-      job = data['jobs'].first
-      step = job['plan'].last
-      step['on_success']['params']['channel'].must_equal '{{slack-channel}}'
+      yaml = builder.build
+      # the Concourse template variable gets interpreted by YAML as a Hash, so check the unparsed version
+      yaml.must_include 'channel: {{slack-channel}}'
     end
   end
 end


### PR DESCRIPTION
Concourse 1.0.0 was fine with the previous format, but Concourse 0.7.6 complained when trying to parse the YAML.
