### PR TITLE
Removing reliance on zap-cli creating new sessions.

### DIFF
--- a/tasks/run-zap/task.sh
+++ b/tasks/run-zap/task.sh
@@ -8,7 +8,6 @@ mkdir -p tmp
 apt-get install jq
 pip install --upgrade zapcli
 
-zap-cli start --start-options '-config api.disablekey=true'
 
 NAME=$(jq -r .name < filtered-project-data/project.json)
 LINK_COUNTER=0
@@ -17,10 +16,11 @@ while [ "$LINK_COUNTER" -lt "$LINK_COUNT" ]; do
   TARGET=$(jq -r ".links | .[${LINK_COUNTER}] | .url" < filtered-project-data/project.json)
 
   echo "Scanning $NAME: $TARGET"
+  zap-cli start --start-options '-config api.disablekey=true'
   # zap-cli `quick-scan` and `alerts` return an error code if there are any warnings - ignore them so the script doesn't fail
   zap-cli -v quick-scan --spider --ajax-spider --scanners all "$TARGET" || true
   zap-cli alerts -l Informational -f json > "tmp/${NAME}.${LINK_COUNTER}.json" || true
-  zap-cli session new
+  zap-cli shutdown
   let LINK_COUNTER+=1
 done
 


### PR DESCRIPTION
This is related to https://github.com/18F/concourse-compliance-testing/issues/48 . Creating new sessions seems unreliable if the session returns a large amount of data. This goes back to starting/shutting down ZAP for each site. Starting/shutting down ZAP is slower, but that is less of an issue now that we are one project per job.
