### PR TITLE
switch back to production being ci.cloud.gov

### DIFF
--- a/pipelines/zap/README.md
+++ b/pipelines/zap/README.md
@@ -35,7 +35,7 @@ The following assumes a Concourse target named `lite`. Run the following from th
 1. Run:
 
     ```bash
-    fly -t cloud login -c https://ci-tooling.cloud.gov
+    fly -t cloud login -c https://ci.cloud.gov
     fly -t cloud sync
     cd pipelines/zap
     rake prod deploy

--- a/pipelines/zap/Rakefile
+++ b/pipelines/zap/Rakefile
@@ -25,10 +25,10 @@ task :local do
   @target = 'lite'
 end
 
-desc "Set the deployment target to be ci-tooling.cloud.gov."
+desc "Set the deployment target to be ci.cloud.gov."
 task :prod do
   @config = 'prod'
-  @origin = 'https://ci-tooling.cloud.gov'
+  @origin = 'https://ci.cloud.gov'
   @target = 'cloud'
 end
 

--- a/pipelines/zap/pipeline.yml
+++ b/pipelines/zap/pipeline.yml
@@ -96,7 +96,7 @@ jobs:
       params:
         text: |
           :x: FAILED to scan properties.
-          <https://ci-tooling.cloud.gov/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+          <https://ci.cloud.gov/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
         channel: {{slack-channel}}
         username: {{slack-user}}
         icon_url: {{slack-icon}}


### PR DESCRIPTION
Per @LinuxBozo [in Slack](https://18f.slack.com/archives/compliance-toolkit/p1460495588001687). Will wait for him to merge once the old URL is gone.
