### PR TITLE
fix incorrect character in 'fly login' command

### DIFF
--- a/pipelines/zap/README.md
+++ b/pipelines/zap/README.md
@@ -35,7 +35,7 @@ The following assumes a Concourse target named `lite`. Run the following from th
 1. Run:
 
     ```bash
-    fly -t cloud login —c https://ci-tooling.cloud.gov
+    fly -t cloud login -c https://ci-tooling.cloud.gov
     fly -t cloud sync
     cd pipelines/zap
     rake prod deploy


### PR DESCRIPTION
It was an em dash before 😫 Could not figure out WHAT was wrong with `fly`. Fixes the issue reported [here](https://18f.slack.com/archives/compliance-toolkit/p1460493566001676).
