### PR TITLE
use the ATC_EXTERNAL_URL instead of hard-coding it

### DIFF
--- a/pipelines/zap/pipeline.yml
+++ b/pipelines/zap/pipeline.yml
@@ -96,7 +96,7 @@ jobs:
       params:
         text: |
           :x: FAILED to scan properties.
-          <https://ci.cloud.gov/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+          <$ATC_EXTERNAL_URL/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
         channel: {{slack-channel}}
         username: {{slack-user}}
         icon_url: {{slack-icon}}


### PR DESCRIPTION
Per @linuxbozo in https://github.com/18F/concourse-compliance-testing/pull/51#discussion_r59564945.
