### PR TITLE
include instructions for how to get the production S3 bucket information

### DIFF
--- a/config/prod.example.yml
+++ b/config/prod.example.yml
@@ -1,8 +1,12 @@
-# aws access controls
+# get the following AWS information from Compliance viewer:
+#
+#   cf target -o cf -s toolkit
+#   cf env compliance-viewer
+#
 aws-access-key:
 aws-secret-key:
-# name of the S3 bucket to use
-aws-bucket: 18f-concourse-collector
+aws-bucket:
+
 # the branch to use for the scripts repo
 script-branch: master
 # webhook for Slack (described here: https://api.slack.com/incoming-webhooks)


### PR DESCRIPTION
Noticed while looking at the S3 config that we don't seem to be updating the `18f-concourse-collector` anymore, and are instead using an S3 instance managed by cloud.gov. Added instructions for how to get that connection information.
## Follow-up TODO
- [x] Delete `18f-concourse-collector` bucket
