### PR TITLE
post in both designated and central Slack channels

### DIFF
--- a/pipelines/zap/pipeline.yml
+++ b/pipelines/zap/pipeline.yml
@@ -95,12 +95,31 @@ jobs:
   - task: summarize-zap-results
     file: scripts/tasks/summarize-zap-results/task.yml
     on_success:
+<% if project['slack_channel'] -%>
+      aggregate:
+      - put: slack
+        params:
+          channel: '#<%= project['slack_channel'] %>'
+          icon_emoji: ':cop:'
+          text_file: zap-summary/summary.txt
+          username: {{slack-user}}
+      # post to the central Slack channel, just for diagnostics
+      - put: slack
+        params:
+          channel: {{slack-channel}}
+          icon_emoji: ':cop:'
+          text: |
+            :white_check_mark: $BUILD_JOB_NAME completed—posted in #<%= project['slack_channel'] %>.
+            <$ATC_EXTERNAL_URL/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+          username: {{slack-user}}
+<% else -%>
       put: slack
       params:
-        channel: <%= project['slack_channel'] ? "'##{project['slack_channel']}'" : "{{slack-channel}}" %>
+        channel: {{slack-channel}}
         icon_emoji: ':cop:'
         text_file: zap-summary/summary.txt
         username: {{slack-user}}
+<% end -%>
     on_failure:
       put: slack
       params:


### PR DESCRIPTION
https://trello.com/c/lQZaEFHF/153-add-per-scan-notifications-in-a-central-channel

Before, if a `slack_channel` was specified in the `targets.json`, the completion notification was only posted in that channel. Now it will be posted there as before (e.g. `#federalist`) _and_ a message will appear in the central channel (the one specified in the pipeline config, e.g. `#ct-bot-attack`).

<img width="470" alt="screen shot 2016-04-27 at 11 46 26 am" src="https://cloud.githubusercontent.com/assets/86842/14860285/b5f03a18-0c6d-11e6-9cb2-e7ea567bdef9.png">
