### PR TITLE
write summary JSON files

### DIFF
--- a/pipelines/zap/pipeline.yml
+++ b/pipelines/zap/pipeline.yml
@@ -42,6 +42,13 @@ resources:
     versioned_file: results/<%= project['name'] %>.json
     access_key_id: {{aws-access-key}}
     secret_access_key: {{aws-secret-key}}
+- name: s3-summary-<%= project['name'] %>
+  type: s3
+  source:
+    bucket: {{aws-bucket}}
+    versioned_file: summaries/<%= project['name'] %>.json
+    access_key_id: {{aws-access-key}}
+    secret_access_key: {{aws-secret-key}}
 - name: fetch-project-data-<%= project['name'] %>
   type: http-resource
   source:
@@ -95,8 +102,8 @@ jobs:
   - task: summarize-zap-results
     file: scripts/tasks/summarize-zap-results/task.yml
     on_success:
-<% if project['slack_channel'] -%>
       aggregate:
+<% if project['slack_channel'] -%>
       - put: slack
         params:
           channel: '#<%= project['slack_channel'] %>'
@@ -113,13 +120,16 @@ jobs:
             <$ATC_EXTERNAL_URL/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
           username: {{slack-user}}
 <% else -%>
-      put: slack
-      params:
-        channel: {{slack-channel}}
-        icon_emoji: ':cop:'
-        text_file: zap-summary/summary.txt
-        username: {{slack-user}}
+      - put: slack
+        params:
+          channel: {{slack-channel}}
+          icon_emoji: ':cop:'
+          text_file: zap-summary/summary.txt
+          username: {{slack-user}}
 <% end -%>
+      - put: s3-summary-<%= project['name'] %>
+        params:
+          file: zap-summary/summary.json
     on_failure:
       put: slack
       params:

--- a/tasks/summarize-zap-results/lib/zap_result_set.rb
+++ b/tasks/summarize-zap-results/lib/zap_result_set.rb
@@ -18,18 +18,22 @@ class ZAPResultSet
   end
 
   def paren_status_count
-    counts = count_risk_levels(project_results)
+    counts = count_risk_levels
     "(#{counts[:high]}/#{counts[:medium]}/#{counts[:low]}/#{counts[:informational]})"
   end
 
-  def count_risk_levels(results)
-    statuses = { high: 0, medium: 0, low: 0, informational: 0 }
-    results.each { |result| statuses[result.risk.downcase.to_sym] += 1 }
-    statuses
+  def count_risk_levels
+    self.class.count_risk_levels(project_results)
   end
 
   def missing?
     !project.source_exists?
+  end
+
+  def self.count_risk_levels(results)
+    statuses = { high: 0, medium: 0, low: 0, informational: 0 }
+    results.each { |result| statuses[result.risk.downcase.to_sym] += 1 }
+    statuses
   end
 
   private

--- a/tasks/summarize-zap-results/lib/zap_result_set_comparator.rb
+++ b/tasks/summarize-zap-results/lib/zap_result_set_comparator.rb
@@ -11,7 +11,12 @@ class ZAPResultSetComparator
     @last_result_set = ZAPResultSet.new(project_name, last_run_dir)
   end
 
-  def write_summary(output_dir)
+  def write_json_summary(output_dir)
+    results = curr_result_set.count_risk_levels
+    File.write("#{output_dir}/summary.json", results.to_json)
+  end
+
+  def write_slack_summary(output_dir)
     txt = "Completed scan of #{project_summary}"
     txt += "\n<https://compliance-viewer.18f.gov/results/#{project_name}/current|View results>"
     File.write("#{output_dir}/summary.txt", txt)
@@ -56,9 +61,12 @@ class ZAPResultSetComparator
     old_results = last_result_set.project_results
     new_results = curr_result_set.project_results
 
+    fixes = old_results - new_results
+    regressions = new_results - old_results
+
     {
-      decreased_counts: last_result_set.count_risk_levels(old_results - new_results),
-      increased_counts: last_result_set.count_risk_levels(new_results - old_results)
+      decreased_counts: ZAPResultSet.count_risk_levels(fixes),
+      increased_counts: ZAPResultSet.count_risk_levels(regressions)
     }
   end
 end

--- a/tasks/summarize-zap-results/task.rb
+++ b/tasks/summarize-zap-results/task.rb
@@ -13,12 +13,14 @@ end
 puts "Comparing last results to current results..."
 comparator = ZAPResultSetComparator.new(project_name, last_run_dir, current_run_dir)
 
+comparator.write_json_summary(output_dir)
+
 # If there is no change, do not write a summary. This prevents Slack from notifying.
 # https://github.com/cloudfoundry-community/slack-notification-resource#parameters
 if comparator.no_change?
   puts "No Change in ZAP results, omitting summary."
 else
-  comparator.write_summary(output_dir)
+  comparator.write_slack_summary(output_dir)
   puts "Generated summary.txt:"
   puts `cat #{output_dir}/summary.txt`
 end

--- a/tasks/summarize-zap-results/test/test_zap_result_set.rb
+++ b/tasks/summarize-zap-results/test/test_zap_result_set.rb
@@ -48,7 +48,7 @@ class TestZAPResultSet < MiniTest::Test
     describe ".count_risk_levels" do
       it "should return correct status counts" do
         result_set = ZAPResultSet.new('fake-site-1', curr_results_dir)
-        counts = result_set.count_risk_levels(result_set.project_results)
+        counts = result_set.count_risk_levels
         assert_equal({ high: 2, medium: 0, low: 1, informational: 1 }, counts)
       end
     end

--- a/tasks/summarize-zap-results/test/test_zap_result_set_comparator.rb
+++ b/tasks/summarize-zap-results/test/test_zap_result_set_comparator.rb
@@ -6,11 +6,28 @@ class TestZAPResultSetComparator < MiniTest::Test
     last_results_dir = "#{__dir__}/last_run"
     curr_results_dir = "#{__dir__}/current_run"
 
-    describe '.write_summary' do
+    describe '.write_json_summary' do
       it "should write correct text file to output dir" do
         Dir.mktmpdir do |output_dir|
           comparator = ZAPResultSetComparator.new('fake-site-1', last_results_dir, curr_results_dir)
-          comparator.write_summary(output_dir)
+          comparator.write_json_summary(output_dir)
+          data = JSON.load(File.new("#{output_dir}/summary.json"))
+          expected = {
+            'high' => 2,
+            'medium' => 0,
+            'low' => 1,
+            'informational' => 1
+          }
+          assert_equal expected, data
+        end
+      end
+    end
+
+    describe '.write_slack_summary' do
+      it "should write correct text file to output dir" do
+        Dir.mktmpdir do |output_dir|
+          comparator = ZAPResultSetComparator.new('fake-site-1', last_results_dir, curr_results_dir)
+          comparator.write_slack_summary(output_dir)
           summary_txt = File.read("#{output_dir}/summary.txt")
           expected = "Completed scan of fake-site-1: (2/0/1/1) has 2 new HIGH, 1 less MEDIUM, 1 less LOW, 1 new INFORMATIONAL, 1 less INFORMATIONAL\n<https://compliance-viewer.18f.gov/results/fake-site-1/current|View results>"
           assert_equal expected, summary_txt
@@ -21,7 +38,7 @@ class TestZAPResultSetComparator < MiniTest::Test
     it "should report NO CHANGE for two empty zap error sets" do
       Dir.mktmpdir do |output_dir|
         comparator = ZAPResultSetComparator.new('fake-site-0', last_results_dir, curr_results_dir)
-        comparator.write_summary(output_dir)
+        comparator.write_slack_summary(output_dir)
         summary_txt = File.read("#{output_dir}/summary.txt")
         expected = "Completed scan of fake-site-0: (0/0/0/0) NO CHANGE\n<https://compliance-viewer.18f.gov/results/fake-site-0/current|View results>"
         assert_equal expected, summary_txt


### PR DESCRIPTION
Doing it differently from before...now, summary JSON files are being written for each project as part of the normal ZAP jobs, then there's a standalone job to pull all of those together into a single file, which will be used for https://trello.com/c/pvGTrseV/150-as-a-user-i-want-to-see-the-zap-status-of-all-the-projects-on-a-single-page.
