### PR TITLE
add a group to the pipeline to see all scheduled jobs

### DIFF
--- a/pipelines/zap/pipeline.yml
+++ b/pipelines/zap/pipeline.yml
@@ -1,5 +1,10 @@
 <%# note that this pipeline file is actually an ERB template, and thus shouldn't be used with `fly` directly -%>
 groups:
+- name: all
+  jobs:
+<% projects.each do |project| -%>
+  - zap-scheduled-<%= project['name'] %>
+<% end -%>
 <% projects.each do |project| -%>
 - name: <%= project['name'] %>
   jobs:


### PR DESCRIPTION
Useful for us to see at a glance if there are issues affecting multiple pipelines (e.g. Micropurchase and Confidential Survey below).

![screen shot 2016-04-28 at 2 04 50 pm](https://cloud.githubusercontent.com/assets/86842/14898000/32488d4a-0d4a-11e6-9c25-8033e93c922e.png)
