### PR TITLE
remove ATF eRegs alerts from that channel

### DIFF
--- a/config/targets.json
+++ b/config/targets.json
@@ -57,7 +57,6 @@
   },
   {
     "name": "atf-eregs",
-    "slack_channel": "atf-eregs",
     "links": [
       {
         "url": "https://atf-eregs-demo.apps.cloud.gov/"


### PR DESCRIPTION
Short of doing https://github.com/18F/concourse-compliance-testing/issues/78, don't post the ATF eRegs alerts in their channel so that team doesn't need to worry about the noise.

/cc @cmc333333
