### PR TITLE
add more cloud.gov sites

### DIFF
--- a/config/targets.json
+++ b/config/targets.json
@@ -81,8 +81,52 @@
   },
 
   {
-    "name": "cg-docs",
+    "name": "cg-api",
     "slack_channel": "cloud-gov-atlas",
+    "skip_team_api": true,
+    "links": [
+      {
+        "url": "https://api.fr.cloud.gov/",
+        "text": "cloud.gov - api"
+      }
+    ]
+  },
+  {
+    "name": "cg-community",
+    "slack_channel": "cloud-gov-liberator",
+    "skip_team_api": true,
+    "links": [
+      {
+        "url": "https://community.fr.cloud.gov/",
+        "text": "cloud.gov - community"
+      }
+    ]
+  },
+  {
+    "name": "cg-concourse",
+    "slack_channel": "cloud-gov-atlas",
+    "skip_team_api": true,
+    "links": [
+      {
+        "url": "https://ci.fr.cloud.gov/",
+        "text": "cloud.gov - concourse"
+      }
+    ]
+  },
+  {
+    "name": "cg-deck",
+    "slack_channel": "cloud-gov-liberator",
+    "skip_team_api": true,
+    "links": [
+      {
+        "url": "https://console.fr.cloud.gov/",
+        "text": "cloud.gov - deck"
+      }
+    ]
+  },
+  {
+    "name": "cg-docs",
+    "slack_channel": "cloud-gov-liberator",
     "skip_team_api": true,
     "links": [
       {
@@ -110,6 +154,17 @@
       {
         "url": "https://logs.fr.cloud.gov/",
         "text": "cloud.gov - logs"
+      }
+    ]
+  },
+  {
+    "name": "cg-metrics",
+    "slack_channel": "cloud-gov-atlas",
+    "skip_team_api": true,
+    "links": [
+      {
+        "url": "https://metrics.fr.cloud.gov/",
+        "text": "cloud.gov - metrics"
       }
     ]
   },

--- a/config/targets.json
+++ b/config/targets.json
@@ -79,36 +79,26 @@
       }
     ]
   },
-  {
-    "name": "cg-landing",
-    "slack_channel": "cloud-gov-liberator",
-    "skip_team_api": true,
-    "links": [
-      {
-        "url": "https://cloud.gov/",
-        "text": "cloud.gov"
-      }
-    ]
-  },
-  {
-    "name": "cg-uaa",
-    "slack_channel": "cloud-gov-atlas",
-    "skip_team_api": true,
-    "links": [
-      {
-        "url": "https://login.cloud.gov/",
-        "text": "cloud.gov - uaa"
-      }
-    ]
-  },
+
   {
     "name": "cg-docs",
     "slack_channel": "cloud-gov-atlas",
     "skip_team_api": true,
     "links": [
       {
-        "url": "https://docs.cloud.gov/",
+        "url": "https://docs.fr.cloud.gov/",
         "text": "cloud.gov - docs"
+      }
+    ]
+  },
+  {
+    "name": "cg-landing",
+    "slack_channel": "cloud-gov-liberator",
+    "skip_team_api": true,
+    "links": [
+      {
+        "url": "https://landing.fr.cloud.gov/",
+        "text": "cloud.gov - landing"
       }
     ]
   },
@@ -118,11 +108,23 @@
     "skip_team_api": true,
     "links": [
       {
-        "url": "https://logs.cloud.gov/",
+        "url": "https://logs.fr.cloud.gov/",
         "text": "cloud.gov - logs"
       }
     ]
   },
+  {
+    "name": "cg-uaa",
+    "slack_channel": "cloud-gov-atlas",
+    "skip_team_api": true,
+    "links": [
+      {
+        "url": "https://login.fr.cloud.gov/",
+        "text": "cloud.gov - uaa/login"
+      }
+    ]
+  },
+
   {
     "name": "epa e-manifest",
     "skip_team_api": true,

--- a/config/targets.json
+++ b/config/targets.json
@@ -102,6 +102,28 @@
     ]
   },
   {
+    "name": "cg-docs",
+    "slack_channel": "cloud-gov-atlas",
+    "skip_team_api": true,
+    "links": [
+      {
+        "url": "https://docs.cloud.gov/",
+        "text": "cloud.gov - docs"
+      }
+    ]
+  },
+  {
+    "name": "cg-logs",
+    "slack_channel": "cloud-gov-atlas",
+    "skip_team_api": true,
+    "links": [
+      {
+        "url": "https://logs.cloud.gov/",
+        "text": "cloud.gov - logs"
+      }
+    ]
+  },
+  {
     "name": "epa e-manifest",
     "skip_team_api": true,
     "links": [


### PR DESCRIPTION
Closes https://github.com/18F/concourse-compliance-testing/issues/89.

Fly'd at https://ci.cloud.gov/pipelines/zap?groups=all-ondemand, and all are green!

/cc @LinuxBozo @dlapiduz 
