### PR TITLE
add BetaFEC sites to ZAP scans

### DIFF
--- a/config/targets.json
+++ b/config/targets.json
@@ -37,6 +37,10 @@
     ]
   },
   {
+    "name": "betafec",
+    "slack_channel": "fec-dev"
+  },
+  {
     "name": "pulse",
     "slack_channel": "pulse",
     "links": [


### PR DESCRIPTION
@LindsayYoung As requested! Results _should_ be visible at https://compliance-viewer.18f.gov/ the day after this is merged, updated nightly. As I mentioned, notifications aren't happening right now because the Slack integration is disabled, but hopefully that issue will be resolved soon.
