### PR TITLE
Add new cloud.gov dashboard project

### DIFF
--- a/config/targets.json
+++ b/config/targets.json
@@ -128,12 +128,22 @@
     ]
   },
   {
-    "name": "cg-deck",
+    "name": "cg-dashboard",
+    "slack_channel": "cloud-gov-liberator",
+    "links": [
+      {
+        "url": "https://dashboard.fr.cloud.gov/",
+        "text": "cloud.gov - dashboard"
+      }
+    ]
+  },
+  {
+    "name": "cg-deck (deprecated)",
     "slack_channel": "cloud-gov-liberator",
     "links": [
       {
         "url": "https://console.fr.cloud.gov/",
-        "text": "cloud.gov - deck"
+        "text": "cloud.gov - deck (deprecated)"
       }
     ]
   },


### PR DESCRIPTION
Update the deck and dashboard projects to make it clear which is the current dashboard and which is the deprecated deck/console

Refs 18f/cg-dashboard#412

cc @afeld or @jcscottiii 
