### PR TITLE
Add in vote.gov staging and production

### DIFF
--- a/config/targets.json
+++ b/config/targets.json
@@ -215,5 +215,19 @@
         "text": "CALC (staging)"
       }
     ]
+  },
+  {
+    "name": "vote.gov",
+    "slack_channel": "ffd-vote",
+    "links": [
+      {
+        "url": "https://vote-gov-staging.apps.cloud.gov",
+        "text": "Vote USA - Staging"
+      },
+      {
+        "url": "https://vote-gov.apps.cloud.gov",
+        "text": "Vote USA - Production"
+      }
+    ]
   }
 ]

--- a/config/targets.json
+++ b/config/targets.json
@@ -223,10 +223,6 @@
       {
         "url": "https://vote-gov-staging.apps.cloud.gov",
         "text": "Vote USA - Staging"
-      },
-      {
-        "url": "https://vote-gov.apps.cloud.gov",
-        "text": "Vote USA - Production"
       }
     ]
   }


### PR DESCRIPTION
With `vote.gov` getting a new ATO, we'd like to have compliance scans for the staging ~~and production~~ version~~s~~ of the site. Updates to the changes introduced in this patch series will be documented in the `18F/vote-gov` repository. 
