### PR TITLE
replace "less" with "fewer"

### DIFF
--- a/tasks/summarize-zap-results/lib/zap_result_set_comparator.rb
+++ b/tasks/summarize-zap-results/lib/zap_result_set_comparator.rb
@@ -52,7 +52,7 @@ class ZAPResultSetComparator
     statuses = []
     [:high, :medium, :low, :informational].each do |level|
       statuses << "#{inc[level]} new #{level.upcase}" if inc[level] > 0
-      statuses << "#{dec[level]} less #{level.upcase}" if dec[level] > 0
+      statuses << "#{dec[level]} fewer #{level.upcase}" if dec[level] > 0
     end
     statuses
   end

--- a/tasks/summarize-zap-results/test/test_zap_result_set_comparator.rb
+++ b/tasks/summarize-zap-results/test/test_zap_result_set_comparator.rb
@@ -28,7 +28,7 @@ describe ZAPResultSetComparator do
         comparator = ZAPResultSetComparator.new('fake-site-1', last_results_dir, curr_results_dir)
         comparator.write_slack_summary(output_dir)
         summary_txt = File.read("#{output_dir}/summary.txt")
-        expected = "Completed scan of fake-site-1: (2/0/1/1) has 2 new HIGH, 1 fewer MEDIUM, 1 fewer LOW, 1 fewer INFORMATIONAL, 1 fewer INFORMATIONAL\n<https://compliance-viewer.18f.gov/results/fake-site-1/current|View results>"
+        expected = "Completed scan of fake-site-1: (2/0/1/1) has 2 new HIGH, 1 fewer MEDIUM, 1 fewer LOW, 1 new INFORMATIONAL, 1 fewer INFORMATIONAL\n<https://compliance-viewer.18f.gov/results/fake-site-1/current|View results>"
         assert_equal expected, summary_txt
       end
     end

--- a/tasks/summarize-zap-results/test/test_zap_result_set_comparator.rb
+++ b/tasks/summarize-zap-results/test/test_zap_result_set_comparator.rb
@@ -28,7 +28,7 @@ describe ZAPResultSetComparator do
         comparator = ZAPResultSetComparator.new('fake-site-1', last_results_dir, curr_results_dir)
         comparator.write_slack_summary(output_dir)
         summary_txt = File.read("#{output_dir}/summary.txt")
-        expected = "Completed scan of fake-site-1: (2/0/1/1) has 2 new HIGH, 1 less MEDIUM, 1 less LOW, 1 new INFORMATIONAL, 1 less INFORMATIONAL\n<https://compliance-viewer.18f.gov/results/fake-site-1/current|View results>"
+        expected = "Completed scan of fake-site-1: (2/0/1/1) has 2 new HIGH, 1 fewer MEDIUM, 1 fewer LOW, 1 fewer INFORMATIONAL, 1 fewer INFORMATIONAL\n<https://compliance-viewer.18f.gov/results/fake-site-1/current|View results>"
         assert_equal expected, summary_txt
       end
     end


### PR DESCRIPTION
> According to prescriptive grammar, "fewer" should be used (instead of "less") with nouns for countable objects and concepts (discretely quantifiable nouns or count nouns).
— [Wikipedia](https://en.wikipedia.org/wiki/Fewer_vs._less)