### PR TITLE
Update CALC target

### DIFF
--- a/config/targets.json
+++ b/config/targets.json
@@ -218,11 +218,11 @@
   },
   {
     "name": "calc",
-    "slack_channel": "calc-data-capture",
+    "slack_channel": "calc",
     "links": [
       {
-        "url": "https://calc-dev.apps.cloud.gov/",
-        "text": "CALC (staging)"
+        "url": "https://calc.gsa.gov/",
+        "text": "CALC"
       }
     ]
   },


### PR DESCRIPTION
Changes the CALC target config to point to our production URL. Also fixes the slack channel name.