### PR TITLE
Updating cg-community results channel

### DIFF
--- a/config/targets.json
+++ b/config/targets.json
@@ -109,7 +109,7 @@
   },
   {
     "name": "cg-community",
-    "slack_channel": "cloud-gov-skyporter",
+    "slack_channel": "cloud-gov-seceng",
     "links": [
       {
         "url": "https://community.fr.cloud.gov/",


### PR DESCRIPTION
#cloud-gov-seceng makes more sense for this than #cloud-gov-skyporter