### PR TITLE
Added new project for periodic owasp scans for staging.login.gov

### DIFF
--- a/config/targets.json
+++ b/config/targets.json
@@ -275,5 +275,15 @@
         "text": "API Program - Developer Hub"
       }
     ]
+  },
+  {
+    "name": "login-dot-gov",
+    "slack_channel": "identity-events",
+    "links": [
+      {
+        "url": "https://idp.staging.login.gov",
+        "text": "Consumer Identity Single Signon Program - Login.gov"
+      }
+    ]
   }
 ]

--- a/config/targets.json
+++ b/config/targets.json
@@ -281,7 +281,7 @@
     "slack_channel": "identity-events",
     "links": [
       {
-        "url": "https://idp.staging.login.gov",
+        "url": "https://staging.login.gov",
         "text": "Consumer Identity Single Signon Program - Login.gov"
       }
     ]


### PR DESCRIPTION
We want to periodically scan https://staging.login.gov but it has basic auth enabled. To bypass basic auth OWASP ZAP server public IP will have to be whitelisted within the login.gov's staging environment.

CC: @jgrevich @mogul 