### PR TITLE
fix Docker permissions issues

### DIFF
--- a/tasks/run-zap/Dockerfile
+++ b/tasks/run-zap/Dockerfile
@@ -1,4 +1,6 @@
 FROM owasp/zap2docker-stable
 
-RUN apt-get install jq
-RUN pip install --upgrade zapcli
+USER root
+RUN apt-get update && apt-get install -q -y --fix-missing jq
+RUN pip install --upgrade pip && pip install --upgrade zapcli
+USER zap

--- a/tasks/run-zap/Dockerfile
+++ b/tasks/run-zap/Dockerfile
@@ -1,6 +1,7 @@
 FROM owasp/zap2docker-stable
 
+# change to root user, which is the owner of the directories we need to write to
 USER root
+
 RUN apt-get update && apt-get install -q -y --fix-missing jq
 RUN pip install --upgrade pip && pip install --upgrade zapcli
-USER zap

--- a/tasks/run-zap/Dockerfile
+++ b/tasks/run-zap/Dockerfile
@@ -1,0 +1,4 @@
+FROM owasp/zap2docker-stable
+
+RUN apt-get install jq
+RUN pip install --upgrade zapcli

--- a/tasks/run-zap/task.sh
+++ b/tasks/run-zap/task.sh
@@ -5,10 +5,6 @@ set -x
 
 mkdir -p tmp
 
-apt-get install jq
-pip install --upgrade zapcli
-
-
 NAME=$(jq -r .name < project-data/project.json)
 LINK_COUNTER=0
 LINK_COUNT=$(jq ".links | length" < project-data/project.json)

--- a/tasks/run-zap/task.yml
+++ b/tasks/run-zap/task.yml
@@ -9,6 +9,6 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: owasp/zap2docker-stable
+    repository: 18fgsa/concourse-compliance-testing
 run:
   path: ./scripts/tasks/run-zap/task.sh


### PR DESCRIPTION
We were getting the following error in the `scan-zap` task:

```
+ mkdir -p tmp
mkdir: cannot create directory 'tmp': Permission denied
```

Working through subsequent issues.